### PR TITLE
use_case_06_add_client is working

### DIFF
--- a/src/AddClient.js
+++ b/src/AddClient.js
@@ -1,54 +1,54 @@
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
-import { addDentist } from "./redux/dentistSlice";
+import { addClient } from "./redux/clientSlice";
 import "./App.css";
 
 import {generateRandomPersonId} from './utils';
 
-const AddDentist = () => {
+const AddClient = () => {
     const log = console.log;
 
     log(`comp AddDentist: start: `)
 
     let dispatch = useDispatch();
-            const addDentistToReduxToolkit = (newDentist) => {
-                dispatch(addDentist(newDentist));
+            const addClientToReduxToolkit = (newClient) => {
+                dispatch(addClient(newClient));
             }
 
             useEffect(() => {
-                // This is how to ADD a dentist, without using a form nor buttons:
+                // This is how to ADD a client, without using a form nor buttons:
 
                 /*
                     winc requirement:
-                    - add a dentist: newState = addDentist(state, "Toos", "Trekker", "06-12345678", "toos@tandartspraktijkbvt.nl")
+                    - add a client: newState = addDentist(state, "Toos", "Trekker", "06-12345678", "toos@tandartspraktijkbvt.nl")
                     
                     This is how to ADD a dental appointment without using a form nor buttons:
                     how to do it:
                     step 1: switch off the other components inside component Appointments. Reason: they both access the same data in redux toolkit with a useEffect with [] as a dependency.
                     step 2: uncomment this component inside component Appointments. 
                     step 3: npm start
-                    step 4: chrome dev tools Redux: the new dentist below has been added to the dentist array inside state.
+                    step 4: chrome dev tools Redux: the new client below has been added to the client array inside state.
 
                     status: works, done.
 
-                    In the bonus requirements I will use a form with a button to add a dentist, instead of using this useEffect hook
+                    In the bonus requirements I will use a form with a button to add a client, instead of using this useEffect hook
 
             
                 */
-                let lastName = "More";
-                let firstName = "Less";
+                let lastName = "Bar";
+                let firstName = "Foo";
 
-               let newDentist = {
+               let newClient = {
                     lastName,
-                    dentistId:`${lastName}-${generateRandomPersonId()}`,
+                    clientId: `${lastName}-${generateRandomPersonId()}`,
                     firstName,
                     phone:"06-61175862",
                     email: `${firstName}.${lastName}@dentistcompanybvt.com`,
-                    treatmentTypes:[],
+                    birthYear: 2001,
                     isSick:"false"
                 }
 
-                addDentistToReduxToolkit(newDentist);
+                addClientToReduxToolkit(newClient);
 
                 }, []
             );
@@ -56,4 +56,4 @@ const AddDentist = () => {
 } 
 
 
-export default AddDentist;
+export default AddClient;

--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,7 @@ import clientsDentistCompanyBVT from "./dataInDentistAppWhenDentistAppStarts/cli
 import dentistsDentistCompanyBVT from "./dataInDentistAppWhenDentistAppStarts/dentists"
 import assistantsDentistCompanyBVT from "./dataInDentistAppWhenDentistAppStarts/assistants"
 
-import { addClient } from "./redux/clientSlice";
+import { addClients } from "./redux/clientSlice";
 import { addDentists } from "./redux/dentistSlice";
 import { addAssistant } from "./redux/assistantSlice";
 import { addAppointment } from "./redux/appointmentSlice";
@@ -41,11 +41,11 @@ const App = ()  => {
   
       useEffect(() => {
           randomClients = getRandomPersons(clientsDentistCompanyBVT, 50);
-          dispatch(addClient(randomClients));
+          log(`App.js inside start of useEffect:`)
+          log(randomClients)
+          dispatch(addClients(randomClients));
       
           randomDentists = getRandomPersons(dentistsDentistCompanyBVT, 4);
-          log(`App.js inside start of useEffect:`)
-          log(randomDentists)
           dispatch(addDentists(randomDentists));
       
           randomAssistants = getRandomPersons(assistantsDentistCompanyBVT, 3); 

--- a/src/Appointment.js
+++ b/src/Appointment.js
@@ -1,14 +1,13 @@
 import React from "react";
 import "./App.css";
 
-
-
 // import InitalSetupForMakingAppointments from "./InitialSetupForMakingAppointments";
 import CreateRandomAppointmentsWhenAppStarts from "./CreateRandomAppointmentsWhenAppStarts";
 import {CreateAppointment} from "./CreateAppointment";
 import DeleteAppointment from "./DeleteAppointment";
 import UpdateAppointment from "./UpdateAppointment";
 import AddDentist from "./AddDentist";
+import AddClient from "./AddClient";
 
 export const Appointment = ({appointments}) =>  {
     return(
@@ -35,6 +34,7 @@ export const Appointment = ({appointments}) =>  {
             {/* <DeleteAppointment/> */}
             {/* <UpdateAppointment/> */}
             <AddDentist />
+            <AddClient />
             <div>the useEffect hook inside each of the components above explains how the functions inside these components can be invoked.</div>
             
         </>

--- a/src/redux/clientSlice.js
+++ b/src/redux/clientSlice.js
@@ -7,11 +7,15 @@ export const clientListSlice = createSlice({
   },
   reducers: {
     addClient: (state, action) => {
-      const randomClientsFromMockaroo = action.payload;
-      state.clients.push(...randomClientsFromMockaroo);
+      const clientToSave = action.payload;
+      state.clients.push(clientToSave);
+    },
+    addClients: (state, action) => {
+      const clientsToSave = action.payload; 
+      state.clients = clientsToSave; // clientsToSave is an array with client objects.
     }}
 })
-export const { addClient } = clientListSlice.actions;
+export const { addClient, addClients } = clientListSlice.actions;
 
 export default clientListSlice.reducer;    
 


### PR DESCRIPTION
                    This is how to ADD a dental appointment without using a form nor buttons:
     
                    step 1: switch off the other components inside component Appointments. Reason: they both access the same data in redux toolkit with a useEffect with [] as a dependency.
                    step 2: uncomment this component inside component Appointments. 
                    step 3: npm start
                    step 4: chrome dev tools Redux: the new client below has been added to the client array inside state.

                    status: works, done.

                    In the bonus requirements I will use a form with a button to add a client, instead of using this useEffect hook