### PR TITLE
use_case_08_give_appointments_of_sick_dentist_a_red_background_color is working

### DIFF
--- a/README_design_to_implement_dentist_app.md
+++ b/README_design_to_implement_dentist_app.md
@@ -1291,11 +1291,21 @@
 
 
 # USE CASE 7: CANCEL APPOINTMENTS BECAUSE CLIENT IS ILL
-    - a client is sick, so delete his appointments: newState = makePatientSick(state, patientId)
-    --> later in the bonus requirements: replace this fn call (inside the business logic of component Appointments) by a button (or stateful checkbox) in the component Client.js . If you click this button (or check the checkbox), then all appointments (0, 1 or more) in the upcoming month will be deleted for this patient. 
-    If time left then implement use case: if the checkbox in component Client.js indicates that that a patient is ill (i.e. is switched on), any attempt to add a new appointment (in component AddAppointment ) will display the alert('Please check that client has cured and is fit enough for a new appointment. If so, please uncheck checkbox 'patient is ill' on webpage Client ). Client will get its own Route and Link in React Router. 
 
-    work flow:
+    - a client is sick, so delete his appointments: newState = makePatientSick(state, patientId)
+
+    UI: as a dentist or assistant on a client page, I select a clientId inside a selectbox. Then
+    I click a button 'cancel all appointments'. The event that is  triggered, contains a clientId.
+    The UI part will be implemented as part of the bonus requirement. Until then I use this useEffect hook to call the fn
+    that deletes all appointments of this clientId. 
+
+    Client page will get its own Route and Link in React Router. 
+
+       
+    
+    alternative UI: a button (or stateful checkbox) in the component Client.js . If you click this button (or check the checkbox), then all appointments (0, 1 or more) in the upcoming month will be deleted for this patient. 
+    
+    alternative work flow:
     1. Component Dlient.js has subcomponent ShowClients.js 
     2. ShowClient.js contains overview with all clients.
     3. On each client row you can select checkbox 'client is ill'
@@ -1307,6 +1317,7 @@
         long as on the Client page the checkbox indicates that the client is ill.
     
 
+
 # USE CASE 8: GIVE APPOINTMENTS OF SICK DENTIST A RED BACKGROUND COLOR
     winc-requirement: "a dentist becomes sick. Give each of his or her appointments a red background colour". --> do this in the Day View and in the Calendar (month) View: 
     newState = makeDentistSick(state, dentistId)" 
@@ -1316,7 +1327,7 @@
     --> where to implement: in component Dentist.js --> subcomponent DisplayDentist.js check checkbox 'dentist is ill'. As a result of this all of his appointments (0, 1 or more) will get a red background color. 
 
 
-    work flow:
+    UI work flow:
     1. Component Dentist.js has subcomponent ShowDentists.js 
     2. ShowDentist.js contains overview with all dentists.
     3. On each dentist row you can select checkbox 'dentist is ill'
@@ -1340,7 +1351,7 @@
         5. now conditionally render the array appointmentsWithSickAndHealthyDentists:  "if isSick, then show red background", else do nothing.  (use nullish coalescing operator.).
 
 
-    5. 'use case 2: (see chapter use case 2): validate that when you make appointment for sick dentist, then the appointment shows up on Calendar View and Day View, but with red background color. 
+    5. 'scenario: (see chapter use case 2): validate that when you make appointment for sick dentist, then the appointment shows up on Calendar View and Day View, but with red background color. 
 
 # USE CASE 9: GIVE APPOINTMENTS OF SICK ASSISTANT AN ORANGE BACKGROUND COLOR
     winc-requirement: "(dentists and) assistants can become sick. They won't be able to work that day."

--- a/src/App.js
+++ b/src/App.js
@@ -208,6 +208,7 @@ const App = ()  => {
 
 
     let appointmentsfromReduxToolkit = useSelector((state) => state.appointment)
+    let dentistsFromReduxToolkit  = useSelector((state) => state.dentist);
 
   return(
     
@@ -256,7 +257,7 @@ const App = ()  => {
           
               <Switch>
                 <Route path="/calendar">
-                  <Calendar appointments={appointmentsfromReduxToolkit} />
+                  <Calendar appointments={appointmentsfromReduxToolkit}  />
                 </Route>
                 <Route path="/deleteAppointment">  
                 <DeleteAppointment  />

--- a/src/Appointment.js
+++ b/src/Appointment.js
@@ -9,6 +9,7 @@ import UpdateAppointment from "./UpdateAppointment";
 import AddDentist from "./AddDentist";
 import AddClient from "./AddClient";
 import DeleteAllAppointmentsOfClient from "./DeleteAllAppointmentsOfClient";
+import MakeRedBackgroundForAppointmentsOfSickDentist from "./MakeRedBackgroundForAppointmentsOfSickDentist";
 
 export const Appointment = ({appointments}) =>  {
     return(
@@ -36,7 +37,8 @@ export const Appointment = ({appointments}) =>  {
             {/* <UpdateAppointment/> */}
             {/* <AddDentist />
             <AddClient /> */}
-            <DeleteAllAppointmentsOfClient />
+            {/* <DeleteAllAppointmentsOfClient /> */}
+            <MakeRedBackgroundForAppointmentsOfSickDentist />
             <div>the useEffect hook inside each of the components above explains how the functions inside these components can be invoked.</div>
             
         </>

--- a/src/AppointmentInDay.js
+++ b/src/AppointmentInDay.js
@@ -1,13 +1,33 @@
 import React from "react";
+import { useSelector } from "react-redux";
+import { selectObjectsByArrayObjectKey } from "./utils";
+const log = console.log;
 
 const format_time = time => (time < 10 ? `0${time}:00u` : `${time}:00u`);
 
-export default ({ time, day, client, dentist, assistant }) => (
-  <li className="appointment">
+export const AppointmentInDay = ({ time, day, client, dentist, assistant, dentistId, assistantId }) => {
+  
+  let dentistsFromReduxToolkit  = useSelector((state) => state.dentist);
+  console.log(dentistId) 
+  let dentistIsSick;
+  
+  // check if dentist is  ill:
+  console.log(`dentists from redux toolkit:`)
+  log(dentistsFromReduxToolkit.dentists)
+  let getDentist = dentist => dentist.dentistId === dentistId
+  let dentistFromreduxToolkit = selectObjectsByArrayObjectKey(dentistsFromReduxToolkit.dentists, getDentist)
+  dentistIsSick = dentistFromreduxToolkit[0].isSick;
+  dentistIsSick = (dentistIsSick === "true" || dentistIsSick === true);
+
+
+  return(
+  <li className="appointment" style={{backgroundColor : dentistIsSick ? 'red' : 'lightyellow'}}>
     <div className="time">{format_time(time)}</div>
     <div className="dayAsNumber">Day number: {day}</div>
     <div className="client">Client: {client}</div>
     <div className="dentist">Tandarts: {dentist}</div>
     <div className="assistant">Assistent: {assistant}</div>
   </li>
-);
+  )
+};
+

--- a/src/AppointmentInMonthDay.js
+++ b/src/AppointmentInMonthDay.js
@@ -1,13 +1,37 @@
 import React from "react";
+import { useSelector } from "react-redux";
+import { dentistListSlice } from "./redux/dentistSlice";
+import { selectObjectsByArrayObjectKey } from "./utils";
+
+const log = console.log;
 
 const format_time = time => (time < 10 ? `${time}:00u` : `${time}:00u`);
 
- export const AppointmentInMonthDay = ({ day, time, client, assistant }) => (
+export const AppointmentInMonthDay = ({day, time, client, dentistId, assistantId }) => {
+  
+  let dentistsFromReduxToolkit  = useSelector((state) => state.dentist);
+  console.log(dentistId) 
+  let dentistIsSick;
+  
+  // check if dentist is  ill:
+  console.log(`dentists from redux toolkit:`)
+  log(dentistsFromReduxToolkit.dentists)
+  let getDentist = dentist => dentist.dentistId === dentistId
+  let dentistFromreduxToolkit = selectObjectsByArrayObjectKey(dentistsFromReduxToolkit.dentists, getDentist)
+  dentistIsSick = dentistFromreduxToolkit[0].isSick;
+  dentistIsSick = (dentistIsSick === "true" || dentistIsSick === true);
 
-  <div className="appointment">
-    <span className="dayAsNumber">{day}</span>    
+
+  return(
+  <div className="appointment" style={{backgroundColor : dentistIsSick ? 'red' : 'lightyellow'}}  >
+    <span className="dayAsNumber">{day} </span>    
     <span className="time">{format_time(time)}</span>
-    <span className="client">{client}</span>
-    <span className="assistant">{assistant}</span> 
+    <span className="client">{client} </span>
+    <span className="dentist">{dentistId}</span> 
+    <span className="assistant">{assistantId}</span> 
   </div>
-);
+  );
+};
+
+
+

--- a/src/Calendar.css
+++ b/src/Calendar.css
@@ -19,11 +19,20 @@
   font-size: 1rem;
 }
 
-.calendarview .day {
+.calendarview  {
   margin-bottom: 0.5rem;
   border: 1px solid lightblue;
   padding: 0.5rem;
   background-color: lightyellow;
+  /* background-color: red; */
+}
+
+.day {
+  margin-bottom: 0.5rem;
+  border: 1px solid lightblue;
+  padding: 0.5rem;
+  /* background-color: lightyellow; */
+  /* background-color: red; */
 }
 
 .appointment {
@@ -47,4 +56,8 @@
 
 .assistant {
   margin-left: 20px;
+}
+
+.backgroundColor {
+  background-color: red;
 }

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -1,6 +1,6 @@
 import React from "react";
-import "./Calendar.css";
 import {DayInMonth} from "./DayInMonth";
+import "./Calendar.css";
 
 const divideByDay = appointments => {
   // console.log('hier')
@@ -16,7 +16,7 @@ const divideByDay = appointments => {
   return appointmentsByDay;
 };
 
-export const Calendar = ( {appointments} ) => {
+export const Calendar = ( {appointments, dentists} ) => {
 
   // let {appointments} = foo;
   // console.log(appointments)
@@ -83,7 +83,7 @@ let sortedStuff = (daysInMonthJSXsorted)
 
     */ 
 
-    <DayInMonth appointments={appointmentsInDay} key={index} />
+    <DayInMonth appointments={appointmentsInDay}  key={index} />
   ));
   // you are mapping all days of the month.
   return (

--- a/src/CreateRandomAppointmentsWhenAppStarts.js
+++ b/src/CreateRandomAppointmentsWhenAppStarts.js
@@ -16,7 +16,11 @@ import {addDayTimeClient} from "./redux/clientDayTimeSlice";
 import {addDayTimeDentist} from "./redux/dentistDayTimeSlice";
 import {addDayTimeAssistant} from "./redux/assistantDayTimeSlice";
 import {addAppointsments} from "./redux/appointmentSlice";
-import { createCombiOfPersonAndDayAndTime, generateRandomAppointmentId, getRandomPersonId, getRandomPersonIdAsync, getRandomDay, getRandomName, getRandomPersons, getRandomTime, selectObjectsByArrayObjectKey } from './utils';
+import { 
+    createCombiOfPersonAndDayAndTime, 
+    generateRandomAppointmentId, 
+    getRandomPersonId, 
+    getRandomPersonIdAsync, getRandomDay, getRandomName, getRandomPersons, getRandomTime, selectObjectsByArrayObjectKey } from './utils';
 
 
 const CreateRandomAppointmentsWhenAppStarts = () => {

--- a/src/Day.js
+++ b/src/Day.js
@@ -1,6 +1,6 @@
 import React from "react";
 import "./Day.css";
-import AppointmentInDay from "./AppointmentInDay";
+import {AppointmentInDay} from "./AppointmentInDay";
 // import { useSelector } from "react-redux"; 
 
 export const Day = ({appointments} ) => {
@@ -13,13 +13,15 @@ export const Day = ({appointments} ) => {
   const appointmentsJSX = appointments
     .sort((appointment1, appointment2) => appointment2.time - appointment1.time).reverse()
     .map(
-      ({ time, day, client, dentist, assistant }, index) => (
+      ({ time, day, client, dentist, assistant, dentistId, assistantId }, index) => (
         <AppointmentInDay
           time={time}
           day={day}
           client={client}
           dentist={dentist}
           assistant={assistant}
+          dentistId={dentistId} 
+          assistantId={assistantId}   
           key={index}
         /> 
       )

--- a/src/DayInMonth.js
+++ b/src/DayInMonth.js
@@ -1,20 +1,28 @@
 import React from "react";
 import {AppointmentInMonthDay} from "./AppointmentInMonthDay";
 
+
 export const DayInMonth = ({ appointments }) => {
-  
   const appointmentsJSX = appointments
     .sort((appointment1, appointment2) => appointment2.time - appointment1.time).reverse()  // works
-    .map(({ time, day, client, assistant }, index) => (
-    <AppointmentInMonthDay  day={day} time={time}  client={client} assistant={assistant} key={index} />
+    .map(({ time, day, client, dentistId, assistantId }, index) => (
+    <AppointmentInMonthDay  
+      day={day} 
+      time={time}  
+      client={client} 
+      dentistId={dentistId} 
+      assistantId={assistantId}   
+      key={index} />
   ));
   // you are mapping all appointments on 1 day.
+
   return(
-    <div className="day">{appointmentsJSX}</div>
+    // <div className="day" style={{backgroundColor : dentistIsSick ? 'red' : 'lightyellow'}}  >{appointmentsJSX}</div>
+    // <div className="day" style={{backgroundColor : 'red' }}  >{appointmentsJSX}</div> // works
+
+    <div className="day" >{appointmentsJSX}</div>
   );
   
 };
-
-
 
 

--- a/src/MakeRedBackgroundForAppointmentsOfSickDentist.js
+++ b/src/MakeRedBackgroundForAppointmentsOfSickDentist.js
@@ -1,0 +1,62 @@
+import React from "react";
+import { useEffect } from "react";
+import { useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
+import {setDentistToSick} from "./redux/dentistSlice";
+import {getDentistId} from './utils';
+import "./App.css";
+
+const log = console.log;
+
+
+const MakeRedBackgroundForAppointmentsOfSickDentist = () => {
+
+    // let clientsfromReduxToolkit = useSelector((state) => state.client)
+    let dentistsfromReduxToolkit = useSelector((state) => state.dentist)
+
+    let dispatch = useDispatch();
+
+            useEffect(() => {
+                /*
+                    winc requirement:
+                    - a client is sick, delete his appointments: newState = makePatientSick(state, patientId)
+                
+                    This is how to give all appointments of a sick dentist in the calendar view and day view a red background color:
+                    step 1: switch off the other components inside component Appointments. 
+                        Reason: they all access (partly) the same data in redux toolkit with a useEffect with [] as a dependency.
+                    step 2: uncomment this component 'MakeRedBackgroundForAppointmentsOfSickDentist' inside component Appointments. 
+                    step 3: npm start
+                    step 4: in calendar view and day view all appointments of the sick dentist have a red background color.
+
+                    status: works, done.
+
+                    In the bonus requirements I will use a form with a button to do the same, instead of using this useEffect hook
+
+                */                  
+                /*
+                    I use this useEffect hook to set in the system that a dentist is ill. In the bonus requirements I will use a UI to do the same:       
+                    
+                    With a UI: as a dentist or assistant on a dentist page, I select a dentistId inside a selectbox. Then
+                    I click a button 'set dentist to ill'. The event that is  triggered, contains the dentistId of the sick dentist.
+                    
+                    The UI part will be implemented as part of the bonus requirement. 
+                */ 
+
+                // step: filter a dentistId inside the (randomly created dentists inside the) dentist array (skip this step when implementing the bonus UI)
+                let dentistIndexInDentistsArray = 0 // select the  first dentist from the 4 randomly generated dentists.
+                let dentistId = getDentistId(dentistsfromReduxToolkit, dentistIndexInDentistsArray) 
+
+                // step: get indexOfDentistInDentistArrayInReduxToolkit
+                let indexOfDentistInDentistArrayInReduxToolkit = dentistsfromReduxToolkit.dentists.findIndex( dentist => dentist.dentistId === dentistId)
+                log(indexOfDentistInDentistArrayInReduxToolkit)
+                dispatch(setDentistToSick(indexOfDentistInDentistArrayInReduxToolkit));
+            
+                },[]
+            );
+            return(
+                <div>Make Red Background For Appointments Of SickDentist</div>
+            )
+} 
+
+
+export default MakeRedBackgroundForAppointmentsOfSickDentist

--- a/src/redux/dentistSlice.js
+++ b/src/redux/dentistSlice.js
@@ -1,5 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
+import {getDentistId, deleteDentalAppointment, selectObjectsByArrayObjectKey} from '../utils';
 
+const log = console.log;
 export const dentistListSlice = createSlice({
   name: "dentists",
   initialState: {
@@ -13,9 +15,24 @@ export const dentistListSlice = createSlice({
     addDentists: (state, action) => {
       const dentistsToSave = action.payload; 
       state.dentists = dentistsToSave; // dentistsToSave is an array with dentist objects.
+    },
+    setDentistToSick: (state, action) => {
+      console.log('inside dentistList Slice:')
+      let indexOfDentistInDentistArrayInReduxToolkit = action.payload; 
+      state.dentists[indexOfDentistInDentistArrayInReduxToolkit].isSick = true; 
+
+      console.log(typeof(indexOfDentistInDentistArrayInReduxToolkit) )
+
+
+
+      // log( state.dentists)
+      // log( state.dentists[indexOfDentistInDentistArrayInReduxToolkit])
+      // state.dentists[indexOfDentistInDentistArrayInReduxToolkit].isSick = true;
+
+      // console.log(dentistObjectOfWhichTheKeySickMustBeSetToTrue, indexOfDentistInDentistArrayInReduxToolkit )
     }}
 })
-export const { addDentist, addDentists } = dentistListSlice.actions;
+export const { addDentist, addDentists, setDentistToSick } = dentistListSlice.actions;
 
 export default dentistListSlice.reducer;    
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -86,6 +86,15 @@ export function getClientId(clientsfromReduxToolkit, indexOfClient) {
   return clientId
 }
 
+export function getDentistId(dentistsfromReduxToolkit, indexOfDentist) {
+  const dentist = dentistsfromReduxToolkit.dentists[indexOfDentist]
+  log('fn getDentistId: start:')
+  console.log(dentist)
+  let dentistId = dentist.dentistId
+  log('fn getDentistId: end.')
+  return dentistId
+}
+
 export const getRandomDay = () => {
   /*
       winc-requirement: The practice is closed on the weekend.


### PR DESCRIPTION
                    This is how to give all appointments of a sick dentist in the calendar view and day view a red background color:
                    step 1: switch off the other components inside component Appointments. 
                        Reason: they all access (partly) the same data in redux toolkit with a useEffect with [] as a dependency.
                    step 2: uncomment this component 'MakeRedBackgroundForAppointmentsOfSickDentist' inside component Appointments. 
                    step 3: npm start
                    step 4: in calendar view and day view all appointments of the sick dentist have a red background color.

                    status: works, done.

                    In the bonus requirements I will use a form with a button to do the same, instead of using a useEffect hook