### PR TITLE
use_case_10_add_assistant is working

### DIFF
--- a/src/AddAssistant.js
+++ b/src/AddAssistant.js
@@ -1,0 +1,60 @@
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { addAssistant } from "./redux/assistantSlice";
+import "./App.css";
+
+import {generateRandomPersonId} from './utils';
+
+const AddAssistant = () => {
+    const log = console.log;
+
+    log(`comp AddAssistant: start: `)
+
+    let dispatch = useDispatch();
+            const addAssistantToReduxToolkit = (newAssistant) => {
+                dispatch(addAssistant(newAssistant));
+            }
+
+            useEffect(() => {
+                // This is how to ADD a assistant, without using a form nor buttons:
+
+                /*
+                    winc requirement: none. 
+                    I quickly reuse code (for adding a assistant) to be able to add assistants as well.
+                    
+                    
+                    This is how to ADD a dental appointment without using a form nor buttons:
+                    how to do it:
+                    step 1: switch off the other components inside component Appointments. 
+                    Reason: they both access the same data in redux toolkit with a useEffect with [] as a dependency.
+                    step 2: uncomment this component inside component Appointments. 
+                    step 3: npm start
+                    step 4: chrome dev tools Redux: the new assistant below has been added to the assistant array inside state.
+
+                    status: works, done.
+
+                    In the bonus requirements I will use a form with a button to add a assistant, instead of using this useEffect hook
+
+            
+                */
+                let lastName = "Helfer";
+                let firstName = "Ayudante";
+
+               let newAssistant = {
+                    lastName,
+                    assistantId:`${lastName}-${generateRandomPersonId()}`,
+                    firstName,
+                    phone:`06${Math.floor(10000000 + Math.random() * 90000000)}`,
+                    email: `${firstName}.${lastName}@dentistcompanybvt.com`,
+                    isSick:"false"
+                }
+
+                addAssistantToReduxToolkit(newAssistant);
+
+                }, []
+            );
+         return null
+} 
+
+
+export default AddAssistant;

--- a/src/AddDentist.js
+++ b/src/AddDentist.js
@@ -42,7 +42,7 @@ const AddDentist = () => {
                     lastName,
                     dentistId:`${lastName}-${generateRandomPersonId()}`,
                     firstName,
-                    phone:"06-61175862",
+                    phone:`06${Math.floor(10000000 + Math.random() * 90000000)}`,
                     email: `${firstName}.${lastName}@dentistcompanybvt.com`,
                     treatmentTypes:[],
                     isSick:"false"

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ import assistantsDentistCompanyBVT from "./dataInDentistAppWhenDentistAppStarts/
 
 import { addClients } from "./redux/clientSlice";
 import { addDentists } from "./redux/dentistSlice";
-import { addAssistant } from "./redux/assistantSlice";
+import { addAssistants } from "./redux/assistantSlice";
 import { addAppointment } from "./redux/appointmentSlice";
 import {addDayTimeClient} from "./redux/clientDayTimeSlice";
 import {addDayTimeDentist} from "./redux/dentistDayTimeSlice";
@@ -49,7 +49,7 @@ const App = ()  => {
           dispatch(addDentists(randomDentists));
       
           randomAssistants = getRandomPersons(assistantsDentistCompanyBVT, 3); 
-          dispatch(addAssistant(randomAssistants));
+          dispatch(addAssistants(randomAssistants));
       } , [] 
     );
     

--- a/src/Appointment.js
+++ b/src/Appointment.js
@@ -11,6 +11,7 @@ import AddClient from "./AddClient";
 import DeleteAllAppointmentsOfClient from "./DeleteAllAppointmentsOfClient";
 import MakeRedBackgroundForAppointmentsOfSickDentist from "./MakeRedBackgroundForAppointmentsOfSickDentist";
 import MakeOrangeBackgroundForAppointmentsOfSickAssistant from "./MakeOrangeBackgroundForAppointmentsOfSickAssistant";
+import AddAssistant from "./AddAssistant";
 
 export const Appointment = ({appointments}) =>  {
     return(
@@ -36,11 +37,14 @@ export const Appointment = ({appointments}) =>  {
             {/* <CreateAppointment />  */}
             {/* <DeleteAppointment/> */}
             {/* <UpdateAppointment/> */}
-            {/* <AddDentist />
-            <AddClient /> */}
+            {/* <AddDentist /> */}
+            {/* <AddClient /> */}
             {/* <DeleteAllAppointmentsOfClient /> */}
-            <MakeRedBackgroundForAppointmentsOfSickDentist />
-            <MakeOrangeBackgroundForAppointmentsOfSickAssistant/>
+
+            {/* <MakeRedBackgroundForAppointmentsOfSickDentist /> */}
+            {/* <MakeOrangeBackgroundForAppointmentsOfSickAssistant/> */}
+                <AddAssistant/>
+
             <div>the useEffect hook inside each of the components above explains how the functions inside these components can be invoked.</div>
             
         </>

--- a/src/AppointmentInDay.js
+++ b/src/AppointmentInDay.js
@@ -52,7 +52,7 @@ export const AppointmentInDay = ({ time, day, client, dentist, assistant, dentis
   return(
   <li className="appointment" style={{backgroundImage : colorToIndicateSickness}}>
     <div className="time">{format_time(time)}</div>
-    <div className="dayAsNumber">Day number: {day}</div>
+    <div className="dayAsNumber">Day: {day}</div>
     <div className="client">Client: {client}</div>
     <div className="dentist">Tandarts: {dentist}</div>
     <div className="assistant">Assistent: {assistant}</div>

--- a/src/Calendar.css
+++ b/src/Calendar.css
@@ -41,9 +41,9 @@
   padding: 0.1rem;
 }
 
-/* .dayAsNumber {
-  margin-right: 0.5 rem;
-} */
+.dayAsNumber {
+  font-weight: 700;
+}
 
 .calendarview .client {
   margin-left: 0.5rem;

--- a/src/Day.css
+++ b/src/Day.css
@@ -23,8 +23,14 @@
 
 .dayview .dayAsNumber {
   float: right;
-  background-color: yellow;
-  
+  /* background-color: yellow; */
+  font-weight: bold;
+  font-size: 1.1rem;
+}
+
+.dayAsNumber {
+  margin-top: 10px;
+  margin-right: 10px;
 }
 
 .dayview .client {

--- a/src/MakeOrangeBackgroundForAppointmentsOfSickAssistant.js
+++ b/src/MakeOrangeBackgroundForAppointmentsOfSickAssistant.js
@@ -25,7 +25,9 @@ const MakeOrangeBackgroundForAppointmentsOfSickAssistant = () => {
                     This is how to give all appointments of a sick assistant in the calendar view and day view a red background color:
                     step 1: switch off the other components inside component Appointments. 
                         Reason: they all access (partly) the same data in redux toolkit with a useEffect with [] as a dependency.
-                    step 2: uncomment this component 'MakeRedBackgroundForAppointmentsOfSickAssistant' inside component Appointments. 
+                    step 2: uncomment inside component Appointments:
+                        a) this component 'MakeOrangeBackgroundForAppointmentsOfSickAssistant'. 
+                        b) component 'MakeRedBackgroundForAppointmentsOfSickDentist'
                     step 3: npm start
                     step 4: in calendar view and day view all appointments of the sick assistant have a red background color.
 

--- a/src/MakeRedBackgroundForAppointmentsOfSickDentist.js
+++ b/src/MakeRedBackgroundForAppointmentsOfSickDentist.js
@@ -25,7 +25,9 @@ const MakeRedBackgroundForAppointmentsOfSickDentist = () => {
                     This is how to give all appointments of a sick dentist in the calendar view and day view a red background color:
                     step 1: switch off the other components inside component Appointments. 
                         Reason: they all access (partly) the same data in redux toolkit with a useEffect with [] as a dependency.
-                    step 2: uncomment this component 'MakeRedBackgroundForAppointmentsOfSickDentist' inside component Appointments. 
+                    step 2: uncomment inside component Appointments:
+                        a) this component MakeRedBackgroundForAppointmentsOfSickDentist
+                        b) component MakeOrangeBackgroundForAppointmentsOfSickAssistant.
                     step 3: npm start
                     step 4: in calendar view and day view all appointments of the sick dentist have a red background color.
 

--- a/src/redux/assistantSlice.js
+++ b/src/redux/assistantSlice.js
@@ -7,8 +7,12 @@ export const assistantListSlice = createSlice({
   },
   reducers: {
     addAssistant: (state, action) => {
-      const randomAssistantsFromMockaroo = action.payload;
-      state.assistants.push(...randomAssistantsFromMockaroo);
+      const assistantToSave = action.payload;
+      state.assistants.push(assistantToSave);
+    },
+    addAssistants: (state, action) => {
+      const assistantsToSave = action.payload; 
+      state.assistants = assistantsToSave; // dentistsToSave is an array with dentist objects.
     },
     setAssistantToSick: (state, action) => {
       console.log('inside assistantList Slice:')
@@ -18,7 +22,7 @@ export const assistantListSlice = createSlice({
       console.log(typeof(index) )
     }}
 })
-export const { addAssistant, setAssistantToSick } = assistantListSlice.actions;
+export const { addAssistant, addAssistants, setAssistantToSick } = assistantListSlice.actions;
 
 export default assistantListSlice.reducer;    
 


### PR DESCRIPTION
Not a winc requirement. I quickly reuse the code (for adding a dentist), to be able to add a dentist as well.

How to ADD a assistant, without using a form nor buttons:
      step 1: switch off the other components inside component Appointments. 
      Reason: they both access the same data in redux toolkit with a useEffect with [] as a dependency.
      step 2: uncomment this component inside component Appointments. 
      step 3: npm start
      step 4: chrome dev tools Redux: the new assistant below has been added to the assistant array inside state.

      status: works, done.

      In the bonus requirements I will use a form with a button to add a assistant, instead of using this useEffect hook